### PR TITLE
Update clojure tasks

### DIFF
--- a/setup/roles/clojure/tasks/main.yml
+++ b/setup/roles/clojure/tasks/main.yml
@@ -17,8 +17,8 @@
 - name: download clojure cli tools install
   become: yes
   ansible.builtin.get_url:
-    url: https://download.clojure.org/install/linux-install-1.10.1.763.sh
-    dest: /tmp/linux-install-1.10.1.763.sh
+    url: https://download.clojure.org/install/linux-install-1.11.1.1208.sh
+    dest: /tmp/linux-install-1.11.1.1208.sh
     mode: 0755
   when: clojure_installed.stat.exists == False
   tags:
@@ -26,7 +26,7 @@
 
 - name: execute clojure cli install
   become: yes
-  shell: /tmp/linux-install-1.10.1.763.sh
+  shell: /tmp/linux-install-1.11.1.1208.sh
   when: clojure_installed.stat.exists == False
   tags:
     - clojure
@@ -36,6 +36,14 @@
   file: path=/tmp/zsh-installer.sh
   args:
     state: absent
+  tags:
+    - clojure
+
+# Install clj-new as a tool
+- name:
+  become: yes
+  ansible.builtin.command:
+    cmd: clojure -Ttools install com.github.seancorfield/clj-new '{:git/tag "v1.2.399"}' :as clj-new
   tags:
     - clojure
 

--- a/setup/roles/clojure/tasks/main.yml
+++ b/setup/roles/clojure/tasks/main.yml
@@ -6,19 +6,28 @@
   tags:
     - clojure
 
+- name: check if clojure is installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/clojure
+  register: clojure_installed
+  tags:
+    - clojure
+
 # Downloads clojure with cli tools, and the next task installs
 - name: download clojure cli tools install
   become: yes
-  get_url:
+  ansible.builtin.get_url:
     url: https://download.clojure.org/install/linux-install-1.10.1.763.sh
     dest: /tmp/linux-install-1.10.1.763.sh
     mode: 0755
+  when: clojure_installed.stat.exists == False
   tags:
     - clojure
 
 - name: execute clojure cli install
   become: yes
   shell: /tmp/linux-install-1.10.1.763.sh
+  when: clojure_installed.stat.exists == False
   tags:
     - clojure
 

--- a/setup/roles/external_microcontrollers/tasks/main.yml
+++ b/setup/roles/external_microcontrollers/tasks/main.yml
@@ -14,23 +14,14 @@
 # This step might fail with a non-zero return code but
 # it is actually ok. If the repo file /etc/yum.repos.d/balena-etcher.repo
 # has bee created, it is ok.
-
-# The default value for stdin: is used in case the prior step is skipped.
-# In that case the variable etcher_repo_installer will include a stdout key
-# that contains info about skipping the step. There will be no content key.
-# Since running both this step and running the prior step depend on the
-# file not existing, if the prior step is skipped, the contents of the
-# variable will not matter. This should probably be switched to a handler
-# to avoid this issue.
-
 - name: Run etcher repo installer
   become: yes
   environment:
     BASH: "/bin/bash"
   ansible.builtin.shell:
     cmd: sh -s --
-    stdin:  "{{ etcher_repo_installer.content | default( etcher_repo_installer.stdout ) }}"
-    creates: "/etc/yum.repos.d/balena-etcher.repo"
+    stdin:  "{{ etcher_repo_installer.content }}"
+  when: etcher_repo_installer.content is defined
   tags:
     external_microcontrollers
 

--- a/setup/run_setup.sh
+++ b/setup/run_setup.sh
@@ -5,4 +5,4 @@
 
 # add -v to the end of this command to see output from every task that is run
 
-~/sys/ansible/env/bin/ansible-playbook playbook.yml -K $@
+~/sys/ansible/env/bin/ansible-playbook playbook.yml -K $@ -v

--- a/setup/run_setup.sh
+++ b/setup/run_setup.sh
@@ -3,6 +3,7 @@
 # To use this to run plays for a single tag or tags use
 # --tags "<comma seperated list of tags to run>"
 
-# add -v to the end of this command to see output from every task that is run
+# -v at the end of this command prints output from every task that is run
+# -v can be removed if the additional information is not needed
 
 ~/sys/ansible/env/bin/ansible-playbook playbook.yml -K $@ -v


### PR DESCRIPTION
Updated clojure to v1.11.1
Added when conditions to only run clojure installation if clojure is not installed
Added clj-new tool install
made verbose output (-v) the default when running run-setup.sh
Changed condition for running the etcher repo installer. Now it only runs when the previous step variable contains the .content attribute